### PR TITLE
Export TagNode so it can be displayed in JSR docs for this package

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export type Token = NonEndingToken | EndOfInputToken;
 // NODE
 // ===== ===== ===== ===== =====
 
-interface TagNode {
+export interface TagNode {
   /**
    * The local name of the element as it appears in the source input.
    */


### PR DESCRIPTION
The contents of `TagNode` are not documentd in the package's page in JSR.

For example: https://jsr.io/@melvdouc/xml-parser@0.1.1/doc/~/RegularTagNode#property_children